### PR TITLE
Pretty rails admin fields and translates

### DIFF
--- a/app/models/concerns/edition_admin.rb
+++ b/app/models/concerns/edition_admin.rb
@@ -1,4 +1,4 @@
-module StreetAdmin
+module EditionAdmin
 extend ActiveSupport::Concern
 
   included do
@@ -6,6 +6,14 @@ extend ActiveSupport::Concern
     rails_admin do
 
       navigation_icon 'fa fa-list'
+
+      list do
+        field :name
+      end
+
+      edit do
+        field :name
+      end
 
     end
 

--- a/app/models/concerns/gift_admin.rb
+++ b/app/models/concerns/gift_admin.rb
@@ -7,6 +7,18 @@ extend ActiveSupport::Concern
 
       navigation_icon 'fa fa-gift'
 
+      list do
+        field :name
+        field :street
+        field :street_number
+      end
+
+      edit do
+        field :name
+        field :street
+        field :street_number
+      end
+
     end
 
   end

--- a/app/models/concerns/street_admin.rb
+++ b/app/models/concerns/street_admin.rb
@@ -7,6 +7,16 @@ extend ActiveSupport::Concern
 
       navigation_icon 'fa fa-road'
 
+      list do
+        field :name
+        field :position
+      end
+
+      edit do
+        field :name
+        field :position
+      end
+      
     end
 
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,5 @@
 class Edition < ActiveRecord::Base
-  include StreetAdmin
+  include EditionAdmin
 
   validates_presence_of :name
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -9,7 +9,7 @@ RailsAdmin.config do |config|
     warden.authenticate! scope: :user
   end
 
-  config.included_models = ['User', 'Street', 'Gift', 'Edition']
+  config.included_models = ['Gift', 'Edition', 'User', 'Street']
 
   config.compact_show_view = false
 
@@ -20,13 +20,13 @@ RailsAdmin.config do |config|
     index                         # mandatory
     new
     export
-    history_index
-    bulk_delete
+    # history_index
+    # bulk_delete
     # member actions
     show
     edit
     delete
-    history_show
+    # history_show
     show_in_app
 
     # Add the nestable action for configured models

--- a/config/locales/rails_admin.ca.yml
+++ b/config/locales/rails_admin.ca.yml
@@ -1,12 +1,12 @@
 ca:
-  home:
-    name: Inici
   views:
     pagination:
       previous: "&laquo; Anterior"
       next: "Següent &raquo;"
       truncate: "…"
   admin:
+    home:
+      name: Inici
     misc:
       search: "Cerca"
       filter: "Filtra"
@@ -22,7 +22,7 @@ ca:
       up: "Amunt"
       down: "Avall"
       navigation: "Navegació"
-      log_out: "Eixir"
+      log_out: "Desconectar"
       ago: "enrere"
     flash:
       successful: "%{name} %{action} amb èxit"
@@ -92,6 +92,8 @@ ca:
         title: "Història de %{model_label} '%{object_label}'"
         menu: "Història"
         breadcrumb: "Història"
+      nestable:
+        menu: "Ordenar carrers"
     form:
       cancel: "Canceŀla"
       basic_info: "Informació bàsica"
@@ -100,9 +102,9 @@ ca:
       one_char: "caràcter"
       char_length_up_to: "longitud fins a"
       char_length_of: "longitud de"
-      save: "Alça"
-      save_and_add_another: "Alça i afegeix-ne un altre"
-      save_and_edit: "Alça i edita"
+      save: "Guardar"
+      save_and_add_another: "Guardar i afegeix-ne un altre"
+      save_and_edit: "Guardar i edita"
       all_of_the_following_related_items_will_be_deleted: "? Els següents elements relacionats poden ser esborrats o quedar òrfens:"
       are_you_sure_you_want_to_delete_the_object: "Segur que voleu eliminar este/a %{model_name}"
       confirmation: "Sí, fes"
@@ -127,3 +129,19 @@ ca:
         default_col_sep: ","
         col_sep: "Separador de columnes"
         col_sep_help: "Deixeu en blanc per al valor per defecte ('%{value}')" # value is default_col_sep
+  activerecord:
+    models:
+      edition: "Edicions"
+      gift: "Inscripcions de Regals"
+      street: "Carrers"
+      user: "Usuaris Administradors"
+    attributes:
+      edition:
+        name: "Nom de l'Edició"
+      gift:
+        name: "Nom de la persona"
+        street: "Nom del Carrer"
+        street_number: "Número de portal"
+      street:
+        name: "Nom del carrer"
+        position: "Posició"

--- a/spec/features/admin_session_spec.rb
+++ b/spec/features/admin_session_spec.rb
@@ -32,7 +32,7 @@ feature "Admin sesions", :type => :feature do
     fill_in 'Contrasenya', with: "qwer1234"
     click_button 'Iniciar sessió'
 
-    click_on 'Eixir'
+    click_on 'Desconectar'
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** Remove unnecessary fields on rails admin #14 

What
====
- Remove unnecessary fields on rails admin. Add logic order.

How
===
- Custom rails admin fields order on list and edit.
- Remove unnecessary fields.
